### PR TITLE
Type fix in Makefile

### DIFF
--- a/WildcatV6.5/Makefile
+++ b/WildcatV6.5/Makefile
@@ -49,7 +49,7 @@ clean:
 	$(CC) $(CFLAGS) -c -o $@ $*.c
 
 .s.o:
-	$(CC) $(AFLAGS) -c -o $@ $*.S
+	$(CC) $(AFLAGS) -c -o $@ $*.s
 
 %.elf: %.lds $(OBJS)
 	$(CC) -o $@ $(OBJS) $(LDFLAGS) -T $<


### PR DESCRIPTION
Changed extension of prerequisites $*.S to lower case in Makefile to allow builds on Linux. Similar to commit c661bb6a.